### PR TITLE
feat: add useNamespace API for existing namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,31 @@ test("resources sync across clusters", async (s) => {
 });
 ```
 
+### Existing Namespaces
+
+When testing resources in namespaces that kest did not create (e.g. system namespaces or namespaces installed by Helm charts), use `useNamespace` to obtain the same namespace-scoped DSL without creating or cleaning up the namespace:
+
+```ts
+test("istio root cert exists", async (s) => {
+  const istio = await s.useNamespace("istio-system");
+  await istio.assert({
+    apiVersion: "v1",
+    kind: "ConfigMap",
+    name: "istio-ca-root-cert",
+    test() {
+      expect(this.data["root-cert.pem"]).toBeDefined();
+    },
+  });
+});
+```
+
+`useNamespace` is also available on `Cluster`:
+
+```ts
+const cluster = await s.useCluster({ context: "kind-kind" });
+const kubeSystem = await cluster.useNamespace("kube-system");
+```
+
 #### CAPI Dynamic Clusters
 
 Kest can resolve [Cluster API](https://cluster-api.sigs.k8s.io/) (CAPI) provisioned clusters automatically. Pass a `ClusterResourceReference` to `useCluster` and Kest will:
@@ -579,6 +604,7 @@ The top-level API surface available in every test callback.
 | `assertList(resource, options?)`                                        | Fetch a list of resources and run assertions                |
 | `assertOne(resource, options?)`                                         | Assert exactly one resource matches, then run assertions    |
 | `newNamespace(name?, options?)`                                         | Create an ephemeral namespace (supports `{ generateName }`) |
+| `useNamespace(name, options?)`                                          | Obtain a `Namespace` for an existing namespace (no cleanup) |
 | `generateName(prefix)`                                                  | Generate a random-suffix name (statistical uniqueness)      |
 | `exec(input, options?)`                                                 | Execute shell commands with optional revert                 |
 | `useCluster(ref, options?)`                                             | Create a cluster-bound API surface                          |
@@ -586,7 +612,7 @@ The top-level API surface available in every test callback.
 
 ### Namespace / Cluster
 
-Returned by `newNamespace()` and `useCluster()` respectively. They expose the same core methods (`apply`, `create`, `assertApplyError`, `assertCreateError`, `applyStatus`, `delete`, `label`, `get`, `assert`, `assertAbsence`, `assertList`, `assertOne`) scoped to their namespace or cluster context. `Cluster` additionally supports `newNamespace` and `useCluster`.
+Returned by `newNamespace()`, `useNamespace()`, and `useCluster()` respectively. They expose the same core methods (`apply`, `create`, `assertApplyError`, `assertCreateError`, `applyStatus`, `delete`, `label`, `get`, `assert`, `assertAbsence`, `assertList`, `assertOne`) scoped to their namespace or cluster context. `Cluster` additionally supports `newNamespace`, `useNamespace`, and `useCluster`.
 
 `Namespace` also exposes a `name` property:
 
@@ -1039,6 +1065,7 @@ await ns.apply({
 | Situation                                              | Approach                                  |
 | ------------------------------------------------------ | ----------------------------------------- |
 | Namespaced resource inside `newNamespace()`            | Use a fixed name (default)                |
+| Resource in pre-existing namespace (`useNamespace()`)  | Use a fixed name (default)                |
 | Same-kind resources created multiple times in one test | `s.generateName` or numbered fixed names  |
 | Cluster-scoped resource (e.g. `ClusterRole`, `CRD`)    | `s.generateName` (no namespace isolation) |
 | Fixed name causes unintended upsert / side effects     | `s.generateName`                          |

--- a/ts/apis/index.ts
+++ b/ts/apis/index.ts
@@ -550,6 +550,38 @@ export interface Scenario {
     options?: undefined | ActionOptions
   ): Promise<Cluster>;
 
+  /**
+   * Obtains a {@link Namespace} interface for an existing namespace.
+   *
+   * Unlike {@link Scenario.newNamespace}, this does **not** create the namespace
+   * and does **not** register a cleanup handler. It verifies the namespace exists
+   * (via `kubectl get namespace <name>`) and returns the same namespace-scoped
+   * DSL surface.
+   *
+   * Use this when testing resources in namespaces that kest did not create, such
+   * as system namespaces or namespaces provisioned by controllers or Helm charts.
+   *
+   * @param name - The name of the existing namespace.
+   * @param options - Retry options such as timeout and polling interval.
+   *
+   * @example
+   * ```ts
+   * const istio = await s.useNamespace("istio-system");
+   * await istio.assert({
+   *   apiVersion: "v1",
+   *   kind: "ConfigMap",
+   *   name: "istio-ca-root-cert",
+   *   test() {
+   *     expect(this.data["root-cert.pem"]).toBeDefined();
+   *   },
+   * });
+   * ```
+   */
+  useNamespace(
+    name: string,
+    options?: undefined | ActionOptions
+  ): Promise<Namespace>;
+
   // BDD(behavior-driven development) actions
 
   /**
@@ -924,13 +956,44 @@ export interface Cluster {
     cluster: ClusterReference,
     options?: undefined | ActionOptions
   ): Promise<Cluster>;
+
+  /**
+   * Obtains a {@link Namespace} interface for an existing namespace in this cluster.
+   *
+   * Unlike {@link Cluster.newNamespace}, this does **not** create the namespace
+   * and does **not** register a cleanup handler. It verifies the namespace exists
+   * (via `kubectl get namespace <name>`) and returns the same namespace-scoped
+   * DSL surface.
+   *
+   * @param name - The name of the existing namespace.
+   * @param options - Retry options such as timeout and polling interval.
+   *
+   * @example
+   * ```ts
+   * const cluster = await s.useCluster({ context: "kind-kind" });
+   * const kubeSystem = await cluster.useNamespace("kube-system");
+   * await kubeSystem.assert({
+   *   apiVersion: "v1",
+   *   kind: "ConfigMap",
+   *   name: "kube-root-ca.crt",
+   *   test() {
+   *     expect(this.data["ca.crt"]).toBeDefined();
+   *   },
+   * });
+   * ```
+   */
+  useNamespace(
+    name: string,
+    options?: undefined | ActionOptions
+  ): Promise<Namespace>;
 }
 
 /**
  * Namespace-bound API surface.
  *
- * A {@link Namespace} is typically obtained via {@link Scenario.newNamespace} or
- * {@link Cluster.newNamespace}.
+ * A {@link Namespace} is typically obtained via {@link Scenario.newNamespace},
+ * {@link Scenario.useNamespace}, {@link Cluster.newNamespace}, or
+ * {@link Cluster.useNamespace}.
  *
  * Operations are scoped by setting the kubectl namespace context (equivalent to
  * passing `kubectl -n <namespace>`).

--- a/ts/scenario/index.ts
+++ b/ts/scenario/index.ts
@@ -61,6 +61,7 @@ export function createScenario(deps: CreateScenarioOptions): InternalScenario {
     but: bdd.but(deps),
     generateName: (prefix: string) => generateRandomName(prefix),
     newNamespace: createNewNamespaceFn(deps),
+    useNamespace: createUseNamespaceFn(deps),
     useCluster: createUseClusterFn(deps),
     async cleanup(options?: { skip?: boolean }) {
       if (options?.skip) {
@@ -197,6 +198,31 @@ export const createQueryFn =
     }
   };
 
+export function buildNamespaceSurface(
+  scenarioDeps: CreateScenarioOptions,
+  namespaceName: string
+): Namespace {
+  const namespacedKubectl = scenarioDeps.kubectl.extends({
+    namespace: namespaceName,
+  });
+  const namespacedDeps = { ...scenarioDeps, kubectl: namespacedKubectl };
+  return {
+    name: namespaceName,
+    apply: createMutateFn(namespacedDeps, apply),
+    create: createMutateFn(namespacedDeps, create),
+    assertApplyError: createMutateFn(namespacedDeps, assertApplyError),
+    assertCreateError: createMutateFn(namespacedDeps, assertCreateError),
+    applyStatus: createOneWayMutateFn(namespacedDeps, applyStatus),
+    delete: createOneWayMutateFn(namespacedDeps, deleteResource),
+    label: createOneWayMutateFn(namespacedDeps, label),
+    get: createQueryFn(namespacedDeps, get),
+    assert: createQueryFn(namespacedDeps, assert),
+    assertAbsence: createQueryFn(namespacedDeps, assertAbsence),
+    assertList: createQueryFn(namespacedDeps, assertList),
+    assertOne: createQueryFn(namespacedDeps, assertOne),
+  };
+}
+
 export const createNewNamespaceFn =
   (scenarioDeps: CreateScenarioOptions) =>
   async (
@@ -207,24 +233,34 @@ export const createNewNamespaceFn =
       name,
       options
     );
-    const { kubectl } = scenarioDeps;
-    const namespacedKubectl = kubectl.extends({ namespace: namespaceName });
-    const namespacedDeps = { ...scenarioDeps, kubectl: namespacedKubectl };
-    return {
-      name: namespaceName,
-      apply: createMutateFn(namespacedDeps, apply),
-      create: createMutateFn(namespacedDeps, create),
-      assertApplyError: createMutateFn(namespacedDeps, assertApplyError),
-      assertCreateError: createMutateFn(namespacedDeps, assertCreateError),
-      applyStatus: createOneWayMutateFn(namespacedDeps, applyStatus),
-      delete: createOneWayMutateFn(namespacedDeps, deleteResource),
-      label: createOneWayMutateFn(namespacedDeps, label),
-      get: createQueryFn(namespacedDeps, get),
-      assert: createQueryFn(namespacedDeps, assert),
-      assertAbsence: createQueryFn(namespacedDeps, assertAbsence),
-      assertList: createQueryFn(namespacedDeps, assertList),
-      assertOne: createQueryFn(namespacedDeps, assertOne),
-    };
+    return buildNamespaceSurface(scenarioDeps, namespaceName);
+  };
+
+export const createUseNamespaceFn =
+  (scenarioDeps: CreateScenarioOptions) =>
+  async (
+    name: string,
+    options?: undefined | ActionOptions
+  ): Promise<Namespace> => {
+    const { kubectl, recorder } = scenarioDeps;
+    const description = `useNamespace("${name}")`;
+    recorder.record("ActionStart", { description });
+    let actionErr: undefined | Error;
+    try {
+      await retryUntil(() => kubectl.get("Namespace", name), {
+        ...options,
+        recorder,
+      });
+      return buildNamespaceSurface(scenarioDeps, name);
+    } catch (error) {
+      actionErr = error as Error;
+      throw error;
+    } finally {
+      recorder.record("ActionEnd", {
+        ok: actionErr === undefined,
+        error: actionErr,
+      });
+    }
   };
 
 const createUseClusterFn =

--- a/ts/scenario/use-cluster.ts
+++ b/ts/scenario/use-cluster.ts
@@ -26,6 +26,7 @@ import {
   createNewNamespaceFn,
   createOneWayMutateFn,
   createQueryFn,
+  createUseNamespaceFn,
 } from "./index";
 
 function isClusterResourceReference(
@@ -56,6 +57,7 @@ export function buildClusterSurface(deps: CreateScenarioOptions): Cluster {
     assertList: createQueryFn(deps, assertList),
     assertOne: createQueryFn(deps, assertOne),
     newNamespace: createNewNamespaceFn(deps),
+    useNamespace: createUseNamespaceFn(deps),
     useCluster: (
       cluster: ClusterReference,
       options?: ActionOptions

--- a/ts/scenario/use-namespace.test.ts
+++ b/ts/scenario/use-namespace.test.ts
@@ -1,0 +1,236 @@
+import { expect, test } from "bun:test";
+import type {
+  Kubectl,
+  KubectlContext,
+  KubectlDeleteOptions,
+  KubectlLabelOptions,
+  KubectlPatch,
+  KubectlPatchOptions,
+} from "../kubectl";
+import { Recorder } from "../recording";
+import type { Reporter } from "../reporter/interface";
+import { createReverting } from "../reverting";
+import { createScenario } from "./index";
+
+type Call = Readonly<{
+  method: "get";
+  type: string;
+  name: string;
+  context: KubectlContext;
+}>;
+
+class FakeKubectl implements Kubectl {
+  private readonly calls: Array<Call>;
+  private readonly ctx: KubectlContext;
+  private readonly getFn: (type: string, name: string) => Promise<string>;
+
+  constructor(
+    calls: Array<Call>,
+    ctx: KubectlContext = {},
+    getFn?: (type: string, name: string) => Promise<string>
+  ) {
+    this.calls = calls;
+    this.ctx = ctx;
+    this.getFn = getFn ?? (() => Promise.resolve(""));
+  }
+
+  extends(overrideContext: KubectlContext): Kubectl {
+    return new FakeKubectl(
+      this.calls,
+      { ...this.ctx, ...overrideContext },
+      this.getFn
+    );
+  }
+
+  apply(): Promise<string> {
+    return Promise.resolve("");
+  }
+
+  applyStatus(): Promise<string> {
+    return Promise.resolve("");
+  }
+
+  create(): Promise<string> {
+    return Promise.resolve("");
+  }
+
+  get(type: string, name: string, context?: KubectlContext): Promise<string> {
+    this.calls.push({
+      method: "get",
+      type,
+      name,
+      context: { ...this.ctx, ...context },
+    });
+    return this.getFn(type, name);
+  }
+
+  list(): Promise<string> {
+    return Promise.resolve("");
+  }
+
+  patch(
+    _resource: string,
+    _name: string,
+    _patch: KubectlPatch,
+    _options?: KubectlPatchOptions
+  ): Promise<string> {
+    return Promise.resolve("");
+  }
+
+  delete(
+    _resource: string,
+    _name: string,
+    _options?: KubectlDeleteOptions
+  ): Promise<string> {
+    return Promise.resolve("");
+  }
+
+  label(
+    _resource: string,
+    _name: string,
+    _labels: Readonly<Record<string, string | null>>,
+    _options?: KubectlLabelOptions
+  ): Promise<string> {
+    return Promise.resolve("");
+  }
+
+  getSecretData(): Promise<string> {
+    return Promise.resolve("");
+  }
+}
+
+const noopReporter: Reporter = {
+  report: async () => "",
+};
+
+test("useNamespace verifies namespace exists via kubectl.get", async () => {
+  const calls: Array<Call> = [];
+  const recorder = new Recorder();
+  const kubectl = new FakeKubectl(calls);
+  const reverting = createReverting({ recorder });
+
+  const scenario = createScenario({
+    name: "useNamespace wiring",
+    recorder,
+    kubectl,
+    reverting,
+    reporter: noopReporter,
+  });
+
+  const ns = await scenario.useNamespace("kube-system");
+
+  expect(ns.name).toBe("kube-system");
+  expect(calls).toHaveLength(1);
+  expect(calls[0]?.method).toBe("get");
+  expect(calls[0]?.type).toBe("Namespace");
+  expect(calls[0]?.name).toBe("kube-system");
+});
+
+test("useNamespace does not register a cleanup handler", async () => {
+  const calls: Array<Call> = [];
+  const recorder = new Recorder();
+  const kubectl = new FakeKubectl(calls);
+  const reverting = createReverting({ recorder });
+
+  const scenario = createScenario({
+    name: "useNamespace no cleanup",
+    recorder,
+    kubectl,
+    reverting,
+    reporter: noopReporter,
+  });
+
+  await scenario.useNamespace("istio-system");
+
+  // Cleanup should be a no-op (no revert handlers registered)
+  await scenario.cleanup();
+
+  // Only the useNamespace get call should have been made — no delete calls
+  expect(calls).toHaveLength(1);
+  expect(calls[0]?.method).toBe("get");
+});
+
+test("useNamespace returns a namespace with scoped actions", async () => {
+  const calls: Array<Call> = [];
+  const recorder = new Recorder();
+  const kubectl = new FakeKubectl(calls);
+  const reverting = createReverting({ recorder });
+
+  const scenario = createScenario({
+    name: "useNamespace scoped",
+    recorder,
+    kubectl,
+    reverting,
+    reporter: noopReporter,
+  });
+
+  const ns = await scenario.useNamespace("my-existing-ns");
+
+  // The returned namespace should have all expected methods
+  expect(typeof ns.apply).toBe("function");
+  expect(typeof ns.create).toBe("function");
+  expect(typeof ns.get).toBe("function");
+  expect(typeof ns.assert).toBe("function");
+  expect(typeof ns.assertAbsence).toBe("function");
+  expect(typeof ns.assertList).toBe("function");
+  expect(typeof ns.assertOne).toBe("function");
+  expect(typeof ns.assertApplyError).toBe("function");
+  expect(typeof ns.assertCreateError).toBe("function");
+  expect(typeof ns.applyStatus).toBe("function");
+  expect(typeof ns.delete).toBe("function");
+  expect(typeof ns.label).toBe("function");
+});
+
+test("useNamespace records ActionStart and ActionEnd events", async () => {
+  const calls: Array<Call> = [];
+  const recorder = new Recorder();
+  const kubectl = new FakeKubectl(calls);
+  const reverting = createReverting({ recorder });
+
+  const scenario = createScenario({
+    name: "useNamespace events",
+    recorder,
+    kubectl,
+    reverting,
+    reporter: noopReporter,
+  });
+
+  await scenario.useNamespace("default");
+
+  const events = recorder.getEvents();
+  const actionStart = events.find((e) => e.kind === "ActionStart");
+  const actionEnd = events.find((e) => e.kind === "ActionEnd");
+
+  expect(actionStart).toBeDefined();
+  expect((actionStart?.data as { description: string }).description).toBe(
+    'useNamespace("default")'
+  );
+  expect(actionEnd).toBeDefined();
+  expect((actionEnd?.data as { ok: boolean }).ok).toBe(true);
+});
+
+test("useNamespace throws when namespace does not exist", async () => {
+  const calls: Array<Call> = [];
+  const recorder = new Recorder();
+  const kubectl = new FakeKubectl(calls, {}, () => {
+    return Promise.reject(new Error('namespaces "nonexistent" not found'));
+  });
+  const reverting = createReverting({ recorder });
+
+  const scenario = createScenario({
+    name: "useNamespace not found",
+    recorder,
+    kubectl,
+    reverting,
+    reporter: noopReporter,
+  });
+
+  await expect(
+    scenario.useNamespace("nonexistent", { timeout: "1s", interval: "100ms" })
+  ).rejects.toThrow();
+
+  const events = recorder.getEvents();
+  const actionEnd = events.find((e) => e.kind === "ActionEnd");
+  expect(actionEnd).toBeDefined();
+  expect((actionEnd?.data as { ok: boolean }).ok).toBe(false);
+});


### PR DESCRIPTION
## Summary

- Add `useNamespace(name, options?)` method to both `Scenario` and `Cluster` interfaces, enabling namespace-scoped DSL for pre-existing namespaces (e.g. `kube-system`, `istio-system`, Helm-installed namespaces)
- Unlike `newNamespace`, `useNamespace` verifies existence via `kubectl get namespace` and does **not** register a cleanup handler
- Extract shared `buildNamespaceSurface` helper to keep `newNamespace` and `useNamespace` DRY

Closes #10

## Test plan

- [x] 5 new unit tests covering: verification via kubectl get, no cleanup registration, scoped action surface, event recording, and not-found error handling
- [x] All 244 existing tests pass
- [x] TypeScript type checking passes (`task typecheck`)
- [x] Biome linter passes (`task lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)